### PR TITLE
feat: editor theme settings implementation

### DIFF
--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/EditorActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/EditorActivity.kt
@@ -120,7 +120,7 @@ class EditorActivity : ComponentActivity() {
 
         setContent {
             JekyllExTheme {
-                EditorView(file, timeout)
+                EditorView(file, theme, timeout)
             }
         }
     }
@@ -132,7 +132,7 @@ class EditorActivity : ComponentActivity() {
 }
 
 @Composable
-fun EditorView(file: String = "", timeout: Int) {
+fun EditorView(file: String = "", theme: Int, timeout: Int) {
     val context = LocalContext.current as Activity
     var showTerminalSheet by remember { mutableStateOf(false) }
     var description by remember { mutableStateOf(file.formatDir("/")) }
@@ -287,7 +287,7 @@ fun EditorView(file: String = "", timeout: Int) {
             }
 
             when (tabIndex) {
-                0 -> Editor(viewCache, file, timeout, innerPadding, isEditorLoading)
+                0 -> Editor(viewCache, file, theme, timeout, innerPadding, isEditorLoading)
                 1 -> Preview(viewCache, file, previewPort, guessedUrl, canPreview, innerPadding, updateDescription) {
                     file.getProjectDir()?.let { dir ->
                         service.exec(jekyll("serve"), dir)

--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/EditorActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/EditorActivity.kt
@@ -116,6 +116,8 @@ class EditorActivity : ComponentActivity() {
         val timeout = Settings(this).get<Float>(Setting.DEBOUNCE_DELAY)
             .times(1000).toInt()
 
+        val theme = Settings(this).get<Int>(Setting.EDITOR_THEME)
+
         setContent {
             JekyllExTheme {
                 EditorView(file, timeout)

--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/components/Editor.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/components/Editor.kt
@@ -79,8 +79,7 @@ fun Editor(
                             val bridge = IOBridge(file, isLoading)
                             addJavascriptInterface(bridge, "IOBridge")
 
-                            loadUrl(file.buildEditorURL(timeout))
-                            loadUrl(file.buildEditorURL(theme))
+                            loadUrl(file.buildEditorURL(theme, timeout))
                         }
                     }
                 }

--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/components/Editor.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/components/Editor.kt
@@ -49,6 +49,7 @@ fun Editor(
     viewCache: SnapshotStateMap<Int, WebView>,
     file: String,
     timeout: Int,
+    theme: Int,
     padding: PaddingValues,
     isLoading: MutableState<Boolean>
 ) {
@@ -79,6 +80,7 @@ fun Editor(
                             addJavascriptInterface(bridge, "IOBridge")
 
                             loadUrl(file.buildEditorURL(timeout))
+                            loadUrl(file.buildEditorURL(theme))
                         }
                     }
                 }

--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/components/Editor.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/components/Editor.kt
@@ -48,8 +48,8 @@ import xyz.jekyllex.utils.buildEditorURL
 fun Editor(
     viewCache: SnapshotStateMap<Int, WebView>,
     file: String,
-    timeout: Int,
     theme: Int,
+    timeout: Int,
     padding: PaddingValues,
     isLoading: MutableState<Boolean>
 ) {

--- a/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
@@ -169,7 +169,7 @@ fun SettingsView() {
                 )
 
                 preferenceCategory(
-                    key = "Editor",
+                    key = "editor_settings",
                     title = { Text("Editor") }
                 )
 
@@ -210,7 +210,7 @@ fun SettingsView() {
                 listPreference(
                     key = EDITOR_THEME.key,
                     values = themeMap.keys.toList(),
-                    title = { Text("Theme Mapping") },
+                    title = { Text(context.getString(R.string.theme_setting_title)) },
                     defaultValue = EDITOR_THEME.defaultValue.get()
                 )
 

--- a/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
@@ -167,6 +167,15 @@ fun SettingsView() {
                     title = { Text("Editor") }
                 )
 
+                listPreference(
+                    key = EDITOR_THEME.key,
+                    values = themeMap.keys.toList(),
+                    defaultValue = EDITOR_THEME.defaultValue.get(),
+                    summary = { Text(themeMap[it] ?: "Unknown theme") },
+                    valueToText = { buildAnnotatedString { append(themeMap[it]) }},
+                    title = { Text(context.getString(R.string.theme_setting_title)) },
+                )
+
                 textFieldPreference(
                     key = PREVIEW_PORT.key,
                     textToValue = {
@@ -199,13 +208,6 @@ fun SettingsView() {
                     valueText = { Text(text = "%.2fs".format(it)) },
                     title = { Text(context.getString(R.string.debounce_setting_title)) },
                     summary = { Text(context.getString(R.string.debounce_setting_summary)) },
-                )
-
-                listPreference(
-                    key = EDITOR_THEME.key,
-                    values = themeMap.keys.toList(),
-                    title = { Text(context.getString(R.string.theme_setting_title)) },
-                    defaultValue = EDITOR_THEME.defaultValue.get()
                 )
 
                 preferenceCategory(

--- a/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
@@ -55,8 +55,10 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.google.firebase.analytics.FirebaseAnalytics
+import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.footerPreference
+import me.zhanghai.compose.preference.listPreference
 import me.zhanghai.compose.preference.preference
 import me.zhanghai.compose.preference.preferenceCategory
 import me.zhanghai.compose.preference.preferenceTheme
@@ -78,6 +80,7 @@ import xyz.jekyllex.utils.Constants.PRIVACY
 import xyz.jekyllex.utils.Constants.LICENSES
 import xyz.jekyllex.utils.Constants.ISSUES_URL
 import xyz.jekyllex.utils.Constants.PAT_SETTINGS_URL
+import xyz.jekyllex.utils.Constants.themeMap
 
 private lateinit var firebaseAnalytics: FirebaseAnalytics
 
@@ -165,14 +168,9 @@ fun SettingsView() {
                     summary = { Text(context.getString(R.string.guess_urls_summary)) },
                 )
 
-                sliderPreference(
-                    valueSteps = 10,
-                    defaultValue = DEBOUNCE_DELAY.defaultValue.get(),
-                    valueRange = .25f..3f,
-                    key = DEBOUNCE_DELAY.key,
-                    valueText = { Text(text = "%.2fs".format(it)) },
-                    title = { Text(context.getString(R.string.debounce_setting_title)) },
-                    summary = { Text(context.getString(R.string.debounce_setting_summary)) },
+                preferenceCategory(
+                    key = "Editor",
+                    title = { Text("Editor") }
                 )
 
                 textFieldPreference(
@@ -197,6 +195,23 @@ fun SettingsView() {
                         Text(context.getString(R.string.preview_port_summary))
                         Text(it.toString())
                     },
+                )
+
+                sliderPreference(
+                    valueSteps = 10,
+                    defaultValue = DEBOUNCE_DELAY.defaultValue.get(),
+                    valueRange = .25f..3f,
+                    key = DEBOUNCE_DELAY.key,
+                    valueText = { Text(text = "%.2fs".format(it)) },
+                    title = { Text(context.getString(R.string.debounce_setting_title)) },
+                    summary = { Text(context.getString(R.string.debounce_setting_summary)) },
+                )
+
+                listPreference(
+                    key = EDITOR_THEME.key,
+                    values = themeMap.keys.toList(),
+                    title = { Text("Theme Mapping") },
+                    defaultValue = EDITOR_THEME.defaultValue.get()
                 )
 
                 preferenceCategory(

--- a/app/src/main/java/xyz/jekyllex/utils/Constants.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Constants.kt
@@ -67,12 +67,12 @@ object Constants {
     )
 
     val themeMap = mapOf(
-        1 to "one-light",
-        2 to "one-dark",
-        3 to "duotone-dark",
-        4 to "duotone-space",
-
+        1 to "One Light",
+        2 to "One Dark",
+        3 to "Duotone Dark",
+        4 to "Duotone Space",
     )
+
     // mime types in android are a mess; somewhat based on
     // https://android.googlesource.com/platform/external/mime-support/+/master/mime.types
     val editorMimes = arrayOf("text/", "xml", "json")

--- a/app/src/main/java/xyz/jekyllex/utils/Constants.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Constants.kt
@@ -71,6 +71,7 @@ object Constants {
         2 to "one-dark",
         3 to "duotone-dark",
         4 to "duotone-space",
+
     )
     // mime types in android are a mess; somewhat based on
     // https://android.googlesource.com/platform/external/mime-support/+/master/mime.types

--- a/app/src/main/java/xyz/jekyllex/utils/Constants.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Constants.kt
@@ -66,6 +66,12 @@ object Constants {
         "yaml" to "yml",
     )
 
+    val themeMap = mapOf(
+        1 to "one-light",
+        2 to "one-dark",
+        3 to "duotone-dark",
+        4 to "duotone-space",
+    )
     // mime types in android are a mess; somewhat based on
     // https://android.googlesource.com/platform/external/mime-support/+/master/mime.types
     val editorMimes = arrayOf("text/", "xml", "json")

--- a/app/src/main/java/xyz/jekyllex/utils/Formatters.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Formatters.kt
@@ -34,6 +34,7 @@ import xyz.jekyllex.utils.Constants.extensionAliases
 import xyz.jekyllex.utils.Constants.defaultExtensions
 import xyz.jekyllex.utils.Setting.DEBOUNCE_DELAY
 import xyz.jekyllex.utils.Setting.PREVIEW_PORT
+import xyz.jekyllex.utils.Setting.EDITOR_THEME
 import java.util.Locale
 
 fun String.getExtension(): String = this
@@ -94,8 +95,10 @@ fun buildStatsString(isDir: Boolean?, size: String?, lastMod: String?): String? 
     return "$dirTag$sizeTag$lastModTag"
 }
 
-fun String.buildEditorURL(timeout: Int = DEBOUNCE_DELAY.defaultValue.get()): String =
-    "$EDITOR_URL/?lang=${this.getExtension()}&timeout=$timeout"
+fun String.buildEditorURL(
+    theme: Int = EDITOR_THEME.defaultValue.get(),
+    timeout: Int = DEBOUNCE_DELAY.defaultValue.get()
+): String = "$EDITOR_URL/?lang=${this.getExtension()}&timeout=$timeout&theme=$theme"
 
 fun String.buildPreviewURL(port: Int = PREVIEW_PORT.defaultValue.get()): String =
     "$PREVIEW_URL:$port" + this.let { if ((it.getOrNull(0) ?: "") == '/') it else "/$it" }

--- a/app/src/main/java/xyz/jekyllex/utils/Settings.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Settings.kt
@@ -96,7 +96,7 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     PREFIX_BUNDLER("prefix_bundler", SettingType.BooleanValue(true)),
     JEKYLL_ENV("jekyll_env", SettingType.StringValue("development")),
 
-    //Editor
+    // Editor
     EDITOR_THEME("set_theme", SettingType.IntValue(1)),
     DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f))
 }

--- a/app/src/main/java/xyz/jekyllex/utils/Settings.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Settings.kt
@@ -74,7 +74,6 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     // General
     TRIM_LOGS("trim_logs", SettingType.BooleanValue(true)),
     GUESS_URLS("guess_urls", SettingType.BooleanValue(true)),
-    DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f)),
     PREVIEW_PORT("default_port", SettingType.IntValue(4000)),
     REDUCE_ANIMATIONS("reduce_animations", SettingType.BooleanValue(false)),
 
@@ -97,6 +96,7 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     PREFIX_BUNDLER("prefix_bundler", SettingType.BooleanValue(true)),
     JEKYLL_ENV("jekyll_env", SettingType.StringValue("development")),
 
-
+    //Editor
     EDITOR_THEME("set_theme", SettingType.IntValue(1)),
+    DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f))
 }

--- a/app/src/main/java/xyz/jekyllex/utils/Settings.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Settings.kt
@@ -96,4 +96,7 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     LIVERELOAD("enable_livereload", SettingType.BooleanValue(true)),
     PREFIX_BUNDLER("prefix_bundler", SettingType.BooleanValue(true)),
     JEKYLL_ENV("jekyll_env", SettingType.StringValue("development")),
+
+
+    EDITOR_THEME("set_theme", SettingType.IntValue(1)),
 }

--- a/app/src/main/java/xyz/jekyllex/utils/Settings.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Settings.kt
@@ -26,7 +26,6 @@ package xyz.jekyllex.utils
 
 import android.content.Context
 import android.preference.PreferenceManager
-import xyz.jekyllex.BuildConfig
 
 class Settings(context: Context) {
     @Suppress("DEPRECATION")
@@ -77,12 +76,15 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     PREVIEW_PORT("default_port", SettingType.IntValue(4000)),
     REDUCE_ANIMATIONS("reduce_animations", SettingType.BooleanValue(false)),
 
+    // Editor
+    EDITOR_THEME("set_theme", SettingType.IntValue(1)),
+    DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f)),
+
     // Git
     GIT_NAME("git_name", SettingType.StringValue("")),
     GIT_EMAIL("git_email", SettingType.StringValue("")),
     GITHUB_PAT("github_pat", SettingType.StringValue("")),
     LOG_PROGRESS("log_progress", SettingType.BooleanValue(false)),
-    ASK_NOTIF_PERM("ask_notif_perm", SettingType.BooleanValue(true)),
 
     // Bundler
     LOCAL_GEMS("local_gems", SettingType.BooleanValue(true)),
@@ -94,7 +96,6 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     PREFIX_BUNDLER("prefix_bundler", SettingType.BooleanValue(true)),
     JEKYLL_ENV("jekyll_env", SettingType.StringValue("development")),
 
-    // Editor
-    EDITOR_THEME("set_theme", SettingType.IntValue(1)),
-    DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f))
+    // Other
+    ASK_NOTIF_PERM("ask_notif_perm", SettingType.BooleanValue(true)),
 }

--- a/app/src/main/java/xyz/jekyllex/utils/Settings.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Settings.kt
@@ -73,11 +73,11 @@ enum class Setting(val key: String, val defaultValue: SettingType) {
     // General
     TRIM_LOGS("trim_logs", SettingType.BooleanValue(true)),
     GUESS_URLS("guess_urls", SettingType.BooleanValue(true)),
-    PREVIEW_PORT("default_port", SettingType.IntValue(4000)),
     REDUCE_ANIMATIONS("reduce_animations", SettingType.BooleanValue(false)),
 
     // Editor
     EDITOR_THEME("set_theme", SettingType.IntValue(1)),
+    PREVIEW_PORT("default_port", SettingType.IntValue(4000)),
     DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f)),
 
     // Git

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,8 @@
     <string name="debounce_setting_summary">
         Time to wait before saving changes to the file being edited (debounce delay).
     </string>
-    <string name="theme_setting_title">Theme Mapping</string>
+
+    <string name="theme_setting_title">Color theme</string>
 
     <string name="docs">Docs</string>
     <string name="report">Report</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,10 +124,10 @@
     </string>
 
     <string name="debounce_setting_title">Editor delay</string>
-    <string name="theme_setting_title">Theme Mapping</string>
     <string name="debounce_setting_summary">
         Time to wait before saving changes to the file being edited (debounce delay).
     </string>
+    <string name="theme_setting_title">Theme Mapping</string>
 
     <string name="crash_reports_title">Report crashes</string>
     <string name="crash_reports_summary">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     </string>
 
     <string name="debounce_setting_title">Editor delay</string>
+    <string name="theme_setting_title">Theme Mapping</string>
     <string name="debounce_setting_summary">
         Time to wait before saving changes to the file being edited (debounce delay).
     </string>


### PR DESCRIPTION
Fixes [#79](https://github.com/jekyllex/jekyllex-android/issues/17)

1. Defined `themeMap` in `Constants.kt` , which maps numbers to different themes.
2. To incorporate the themes into the Settings, I added a ` listPreference` under a new `preferenceCategory` called `Editor` in `SettingsActivity.kt` to allow selection of a theme on the user end. 
3. Updated `buildEditorUrl()` to pass `&theme=<id>` based on user preference. 
4. Modified the `Editor` composable in `Editor.kt` to apply the selected theme. 
