### PR TITLE
feat: bind default session's dir to the file explorer

### DIFF
--- a/app/src/main/java/xyz/jekyllex/services/ProcessService.kt
+++ b/app/src/main/java/xyz/jekyllex/services/ProcessService.kt
@@ -44,6 +44,7 @@ import xyz.jekyllex.utils.Constants.HOME_DIR
 import xyz.jekyllex.utils.NativeUtils.buildEnvironment
 import xyz.jekyllex.utils.Setting
 import xyz.jekyllex.utils.Settings
+import xyz.jekyllex.utils.formatDir
 import xyz.jekyllex.utils.transform
 
 class ProcessService : Service() {
@@ -147,7 +148,12 @@ class ProcessService : Service() {
     }
 
     fun cd(dir: String) {
-        _sessions.value.first().cd(dir)
+        val defaultSession = _sessions.value.first()
+        val currentDir = defaultSession.dir.value
+        defaultSession.cd(dir)
+        defaultSession.appendLog(
+            "${currentDir.formatDir("/")} $ cd ${dir.formatDir("/")}"
+        )
     }
 
     fun exec(cmd: Array<String>, dir: String? = null, callBack: () -> Unit = {}) {

--- a/app/src/main/java/xyz/jekyllex/ui/activities/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/home/HomeViewModel.kt
@@ -45,7 +45,6 @@ import xyz.jekyllex.utils.Commands.shell
 import xyz.jekyllex.utils.Commands.stat
 import xyz.jekyllex.utils.Constants.HOME_DIR
 import xyz.jekyllex.utils.NativeUtils
-import xyz.jekyllex.utils.formatDir
 import xyz.jekyllex.utils.getFilesInDir
 import xyz.jekyllex.utils.parseOutput
 import xyz.jekyllex.utils.mergeCommands
@@ -89,8 +88,6 @@ class HomeViewModel(private var skipAnimations: Boolean) : ViewModel() {
     val filesCount
         get() = _availableFiles.value.size
 
-    var appendLog: (String) -> Unit = {}
-
     init {
         cd(HOME_DIR)
     }
@@ -118,16 +115,9 @@ class HomeViewModel(private var skipAnimations: Boolean) : ViewModel() {
     }
 
     fun cd(dir: String) {
-        statsJob?.let { it.cancel(); statsJob = null; Log.d(LOG_TAG, "Cancelled stats job") }
-        appendLog("${_cwd.value.formatDir("/")} $ cd ${dir.formatDir("/")}")
-
-        if (dir == "..")
-            _cwd.value = _cwd.value.substringBeforeLast('/')
-        else if (dir[0] == '/')
-            _cwd.value = dir
-        else
-            _cwd.value += "/$dir"
-
+        if (dir == _cwd.value) return
+        statsJob?.let { it.cancel(); statsJob = null }
+        _cwd.value = dir
         refresh()
     }
 

--- a/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
@@ -105,6 +105,11 @@ fun TerminalSheet(
     val sessions = sessionManager.sessions.collectAsState().value
     val activeSession = sessionManager.activeSession.collectAsState().value
 
+    val sessionDir = combine(
+        sessionManager.sessions, sessionManager.activeSession
+    ) { s, activeS -> s[activeS] }.flatMapLatest { it.dir }
+        .collectAsState(initial = "").value
+
     val logs: List<String> = combine(
         sessionManager.sessions, sessionManager.activeSession
     ) { s, activeS -> s[activeS] }.flatMapLatest { it.logs }
@@ -263,8 +268,8 @@ fun TerminalSheet(
                     Text(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        text = sessionDir.formatDir("/"),
                         style = MaterialTheme.typography.bodySmall,
-                        text = sessions[activeSession].dir.formatDir("/"),
                     )
                     Row(modifier = Modifier.padding(top = 4.dp)) {
                         BasicTextField(

--- a/app/src/main/java/xyz/jekyllex/utils/Constants.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Constants.kt
@@ -43,7 +43,7 @@ object Constants {
     const val TERMS = "$HOME_PAGE/terms-and-conditions"
     const val EDITOR_URL = "https://editor.jekyllex.xyz"
     const val PREVIEW_URL = "http://localhost"
-    const val COMMAND_NOT_ALLOWED = "Command not allowed"
+    const val COMMAND_NOT_ALLOWED = "Command not allowed!"
     const val PAT_SETTINGS_URL = "https://$GITHUB_DOMAIN/settings/tokens/new"
     const val EDITOR_PREVIEWS_URL = "https://$GITHUB_DOMAIN/jekyllex/editor#previews"
     const val ISSUES_URL = "https://$GITHUB_DOMAIN/jekyllex/jekyllex-android/issues/new/choose"

--- a/app/src/main/java/xyz/jekyllex/utils/Utils.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Utils.kt
@@ -95,15 +95,11 @@ fun Array<String>.transform(context: Context): Array<String> = this.let {
 
 fun Array<String>.override(session: Session): (() -> Unit)? {
     if (this.isDenied()) {
-        return { session.appendLog("$COMMAND_NOT_ALLOWED!") }
+        return { session.appendLog(COMMAND_NOT_ALLOWED) }
     }
     return when (this.getOrNull(0)) {
         "cd" -> {
-            if (session.initialDir != null) {
-                { session.appendLog("$COMMAND_NOT_ALLOWED in the default session!") }
-            } else {
-                { session.cd(this.getOrNull(1) ?: "") }
-            }
+            { session.cd(this.getOrNull(1) ?: "") }
         }
         "clear" -> {
             { session.clearLogs(); }


### PR DESCRIPTION
This PR introduces two way communication between the default session's working directory and the file explorer in the home activity.

Thus, clicking items on the home page shows up as a `cd` command in the terminal, as well as `cd <dir>` in the terminal opens the specific section in the UI which is pretty helpful!