### PR TITLE
feat: long press to open files in an external editor

### DIFF
--- a/app/src/main/java/xyz/jekyllex/ui/activities/home/HomeActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/home/HomeActivity.kt
@@ -120,6 +120,7 @@ import xyz.jekyllex.utils.NativeUtils
 import xyz.jekyllex.utils.getProjectDir
 import xyz.jekyllex.utils.removeSymlinks
 import xyz.jekyllex.ui.components.GenericDialog
+import xyz.jekyllex.utils.openInExternalApp
 import java.io.File as JFile
 
 private lateinit var service: ProcessService
@@ -470,7 +471,7 @@ fun HomeScreen(
                         }
                     }
 
-                    items(files.size) {
+                    items(files.size, key = { homeViewModel.cwd.value + files[it].path }) {
                         FileButton(
                             file = files[it],
                             modifier = Modifier.padding(8.dp),
@@ -480,6 +481,9 @@ fun HomeScreen(
                                     resetQuery()
                                     if (homeViewModel.isBound) service.cd(files[it].name)
                                 } else files[it].open(context)
+                            },
+                            onLongClick = {
+                                if (!files[it].isDir) files[it].openInExternalApp(context, true)
                             }
                         )
                     }

--- a/app/src/main/java/xyz/jekyllex/ui/activities/home/HomeActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/home/HomeActivity.kt
@@ -93,12 +93,14 @@ import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import java.io.File as JFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import xyz.jekyllex.R
 import xyz.jekyllex.services.ProcessService
 import xyz.jekyllex.ui.activities.home.components.DropDownMenu
+import xyz.jekyllex.ui.components.GenericDialog
 import xyz.jekyllex.ui.components.JekyllExAppBar
 import xyz.jekyllex.ui.components.FileButton
 import xyz.jekyllex.ui.components.TerminalSheet
@@ -119,9 +121,7 @@ import xyz.jekyllex.utils.toCommand
 import xyz.jekyllex.utils.NativeUtils
 import xyz.jekyllex.utils.getProjectDir
 import xyz.jekyllex.utils.removeSymlinks
-import xyz.jekyllex.ui.components.GenericDialog
 import xyz.jekyllex.utils.openInExternalApp
-import java.io.File as JFile
 
 private lateinit var service: ProcessService
 
@@ -480,7 +480,9 @@ fun HomeScreen(
                                 if (files[it].isDir) {
                                     resetQuery()
                                     if (homeViewModel.isBound) service.cd(files[it].name)
-                                } else files[it].open(context)
+                                } else if (!files[it].name.contains(".gitconfig")) {
+                                    files[it].open(context)
+                                }
                             },
                             onLongClick = {
                                 if (!files[it].isDir) files[it].openInExternalApp(context, true)

--- a/app/src/main/java/xyz/jekyllex/ui/components/FileButton.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/components/FileButton.kt
@@ -26,7 +26,6 @@ package xyz.jekyllex.ui.components
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import android.webkit.URLUtil
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
@@ -80,8 +79,8 @@ fun FileButton(
 ) {
     val context = LocalContext.current
     val viewConfiguration = LocalViewConfiguration.current
-    val interactionSource = remember { MutableInteractionSource() }
     val openDeleteDialog = remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
 
     LaunchedEffect (interactionSource) {
         var isLongClick = false

--- a/app/src/main/java/xyz/jekyllex/utils/Utils.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Utils.kt
@@ -124,19 +124,18 @@ fun File.removeSymlinks() {
 }
 
 fun FileModel.open(context: Context) {
-    if (name.contains(".gitconfig")) return
     val defaultAction = {
         context.startActivity(
             Intent(context, EditorActivity::class.java)
-                .putExtra("file", path)
+                .putExtra("file", this.path)
         )
     }
 
-    val ext = path.getExtension()
+    val ext = this.path.getExtension()
     val mime = ext.mimeType()
 
     if (
-        name.startsWith(".") ||
+        this.name.startsWith(".") ||
         editorExtensions.contains(ext) ||
         editorMimes.any { mime.contains(it) }
     ) defaultAction()


### PR DESCRIPTION
This PR introduces the option to long press a file on the home page to access the "Open with" model. This is helpful to be able to edit files from an external code editor.

Fixes #30 