### PR TITLE
feat: improve session navigation

### DIFF
--- a/app/src/main/java/xyz/jekyllex/models/Session.kt
+++ b/app/src/main/java/xyz/jekyllex/models/Session.kt
@@ -156,13 +156,13 @@ data class Session(
             file == ".." -> currentDir.substringBeforeLast('/')
             else -> if (currentDir.last() == '/') "$currentDir$file" else "$currentDir/$file"
         }
-        val jFile = File(newDir)
+        val jFile = File(newDir).canonicalFile
         if (!jFile.exists() || !jFile.isDirectory) {
             appendLog("cd: no such file or directory: $loc")
-        } else if (number == 0 && !jFile.canonicalPath.startsWith(HOME_DIR)) {
+        } else if (number == 0 && (!jFile.path.startsWith(HOME_DIR) || jFile.name.startsWith("."))) {
             appendLog(COMMAND_NOT_ALLOWED)
         } else {
-            _dir.value = jFile.canonicalPath
+            _dir.value = jFile.path
         }
     }
 

--- a/app/src/main/java/xyz/jekyllex/services/ProcessService.kt
+++ b/app/src/main/java/xyz/jekyllex/services/ProcessService.kt
@@ -117,7 +117,11 @@ class ProcessService : Service() {
                 val shouldTrim = settings.get<Boolean>(Setting.TRIM_LOGS)
 
                 _sessions.value.apply {
-                    _sessions.update { it + Session(sessionCount++, ::buildEnvironment) }
+                    _sessions.update {
+                        it + Session(sessionCount++, ::buildEnvironment).apply {
+                            cd(_sessions.value[_activeSession.value].dir.value)
+                        }
+                    }
                     forEach { it.setLogTrimming(shouldTrim) }
                 }
 


### PR DESCRIPTION
This PR adds changes that improve terminal sessions navigation.

- New sessions now begin with current session's working directory. No need to manually `cd` just to run a command.
- Use canonical file to validate destination dir path when guarding the default session from entering prohibited directories.