### PR TITLE
feat: command templates for projects

### DIFF
--- a/app/src/main/java/xyz/jekyllex/models/Command.kt
+++ b/app/src/main/java/xyz/jekyllex/models/Command.kt
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Gourav Khunger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package xyz.jekyllex.models
+
+data class Command(
+    val name: String,
+    val command: String
+)

--- a/app/src/main/java/xyz/jekyllex/models/Session.kt
+++ b/app/src/main/java/xyz/jekyllex/models/Session.kt
@@ -97,8 +97,7 @@ data class Session(
 
     private fun processQueue(dir: String? = null, callBack: () -> Unit) {
         if (queue.isEmpty()) { callBack(); return }
-        val cmd = queue.removeAt(0)
-        exec(cmd, dir) { processQueue(dir, callBack) }
+        exec(queue.removeAt(0), dir) { processQueue(dir, callBack) }
     }
 
     fun exec(

--- a/app/src/main/java/xyz/jekyllex/models/Session.kt
+++ b/app/src/main/java/xyz/jekyllex/models/Session.kt
@@ -55,12 +55,13 @@ data class Session(
     private lateinit var process: Process
     private lateinit var reader: BufferedReader
     private val processBuilder = ProcessBuilder()
+    private val queue: MutableList<Array<String>> = mutableListOf()
 
     private var _dir = MutableStateFlow(initialDir ?: HOME_DIR)
     val dir get() = _dir.asStateFlow()
 
     private var _isRunning = mutableStateOf(false)
-    val isRunning get() = _isRunning.value
+    val isRunning get() = _isRunning.value || queue.isNotEmpty()
 
     private val _logs = MutableStateFlow(emptyList<String>())
     val logs get() = _logs.asStateFlow()
@@ -81,6 +82,23 @@ data class Session(
 
     fun setLogTrimming(shouldTrim: Boolean) {
         trimLogs = shouldTrim
+    }
+
+    fun exec(
+        command: Array<Array<String>>,
+        overrideDir: String? = null,
+        callBack: () -> Unit = {}
+    ) {
+        if (isRunning) return
+
+        queue.addAll(command)
+        processQueue(overrideDir, callBack)
+    }
+
+    private fun processQueue(dir: String? = null, callBack: () -> Unit) {
+        if (queue.isEmpty()) { callBack(); return }
+        val cmd = queue.removeAt(0)
+        exec(cmd, dir) { processQueue(dir, callBack) }
     }
 
     fun exec(

--- a/app/src/main/java/xyz/jekyllex/models/Template.kt
+++ b/app/src/main/java/xyz/jekyllex/models/Template.kt
@@ -24,7 +24,12 @@
 
 package xyz.jekyllex.models
 
-data class Command(
-    val name: String,
-    val command: String
-)
+data class Template(
+    val project: String,
+    val commands: List<Command>
+) {
+    data class Command(
+        val name: String,
+        val command: String
+    )
+}

--- a/app/src/main/java/xyz/jekyllex/services/ProcessService.kt
+++ b/app/src/main/java/xyz/jekyllex/services/ProcessService.kt
@@ -138,11 +138,11 @@ class ProcessService : Service() {
                 _activeSession.value = index
             }
 
-            override fun exec(cmd: Array<String>) {
-                val command = cmd.let {
+            override fun exec(cmd: Array<Array<String>>) {
+                val command = cmd.map {
                     if (it[0].contains("/bin")) it
                     else it.transform(this@ProcessService)
-                }
+                }.toTypedArray()
 
                 _sessions.value.let { it[_activeSession.value] }.exec(command)
             }
@@ -255,7 +255,7 @@ interface SessionManager {
     fun clearLogs()
     fun killProcess()
     fun createSession()
-    fun exec(cmd: Array<String>)
     fun deleteSession(index: Int)
     fun setActiveSession(index: Int)
+    fun exec(cmd: Array<Array<String>>)
 }

--- a/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/settings/SettingsActivity.kt
@@ -270,6 +270,11 @@ fun SettingsView() {
                     summary = { Text(context.getString(R.string.reduce_animations_summary)) },
                 )
 
+                preferenceCategory(
+                    key = "terminal_settings",
+                    title = { Text("Terminal") }
+                )
+
                 switchPreference(
                     key = TRIM_LOGS.key,
                     defaultValue = TRIM_LOGS.defaultValue.get(),
@@ -278,10 +283,10 @@ fun SettingsView() {
                 )
 
                 switchPreference(
-                    key = GUESS_URLS.key,
-                    defaultValue = GUESS_URLS.defaultValue.get(),
-                    title = { Text(context.getString(R.string.guess_urls_title)) },
-                    summary = { Text(context.getString(R.string.guess_urls_summary)) },
+                    key = COMMAND_TEMPLATES.key,
+                    defaultValue = COMMAND_TEMPLATES.defaultValue.get(),
+                    title = { Text(context.getString(R.string.command_templates_title)) },
+                    summary = { Text(context.getString(R.string.command_templates_summary)) },
                 )
 
                 preferenceCategory(
@@ -314,6 +319,28 @@ fun SettingsView() {
                     },
                 )
 
+                sliderPreference(
+                    valueSteps = 10,
+                    defaultValue = DEBOUNCE_DELAY.defaultValue.get(),
+                    valueRange = .25f..3f,
+                    key = DEBOUNCE_DELAY.key,
+                    valueText = { Text(text = "%.2fs".format(it)) },
+                    title = { Text(context.getString(R.string.debounce_setting_title)) },
+                    summary = { Text(context.getString(R.string.debounce_setting_summary)) },
+                )
+
+                preferenceCategory(
+                    key = "preview_settings",
+                    title = { Text("Preview") }
+                )
+
+                switchPreference(
+                    key = GUESS_URLS.key,
+                    defaultValue = GUESS_URLS.defaultValue.get(),
+                    title = { Text(context.getString(R.string.guess_urls_title)) },
+                    summary = { Text(context.getString(R.string.guess_urls_summary)) },
+                )
+
                 textFieldPreference(
                     key = PREVIEW_PORT.key,
                     textToValue = {
@@ -336,16 +363,6 @@ fun SettingsView() {
                         Text(context.getString(R.string.preview_port_summary))
                         Text(it.toString())
                     },
-                )
-
-                sliderPreference(
-                    valueSteps = 10,
-                    defaultValue = DEBOUNCE_DELAY.defaultValue.get(),
-                    valueRange = .25f..3f,
-                    key = DEBOUNCE_DELAY.key,
-                    valueText = { Text(text = "%.2fs".format(it)) },
-                    title = { Text(context.getString(R.string.debounce_setting_title)) },
-                    summary = { Text(context.getString(R.string.debounce_setting_summary)) },
                 )
 
                 preferenceCategory(

--- a/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
@@ -146,13 +146,14 @@ fun TerminalSheet(
         sessionsListState.animateScrollToItem(activeSession)
     }
 
-    LaunchedEffect(activeSession, sessionDir, state.isVisible) {
+    LaunchedEffect(sessionDir, state.isVisible) {
         sessionDir.getProjectDir()?.let { dir ->
             if (template?.project == dir) return@LaunchedEffect
             NativeUtils.exec(getProjectCommands(), CoroutineScope(Dispatchers.IO), dir) { out ->
                 out.split("\u001F").takeIf { it.size > 1 && it.size % 2 == 0 }
                     ?.let { it.chunked(2).map { (name, cmd) -> Template.Command(name, cmd) } }
                     ?.let { template = Template(dir, it) }
+                    ?: run { template = null }
             }
         } ?: run { template = null }
     }

--- a/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
@@ -25,6 +25,12 @@
 package xyz.jekyllex.ui.components
 
 import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -33,9 +39,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -53,6 +61,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -200,7 +209,7 @@ fun TerminalSheet(
                     Text(text = "Clear")
                 }
             }
-            LazyRow (
+            LazyRow(
                 state = sessionsListState,
                 modifier = Modifier.padding(bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -283,17 +292,52 @@ fun TerminalSheet(
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
                 Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    AnimatedContent(
+                        label = "Description animation",
+                        targetState = projectCommands,
+                        transitionSpec = {
+                            fadeIn() + slideInVertically(animationSpec = tween(400)) togetherWith
+                                    fadeOut(animationSpec = tween(200))
+                        }
+                    ) { commands ->
+                        if (commands.isEmpty()) return@AnimatedContent
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.padding(top = 2.dp, bottom = 8.dp)
+                        ) {
+                            items(commands.size) { i ->
+                                OutlinedButton(
+                                    onClick = { text = commands[i].command },
+                                    border = BorderStroke(1.dp, Color.LightGray),
+                                    contentPadding = PaddingValues(horizontal = 6.dp),
+                                    modifier = Modifier.height(24.dp).widthIn(max = 150.dp),
+                                ) {
+                                    Text(
+                                        color = Color.DarkGray,
+                                        overflow = TextOverflow.Ellipsis,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        text = commands[i].name.ifBlank { commands[i].command },
+                                        modifier = Modifier.padding(
+                                            horizontal = 4.dp,
+                                            vertical = 2.dp
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                    }
                     Text(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         text = sessionDir.formatDir("/"),
-                        style = MaterialTheme.typography.bodySmall,
+                        style = MaterialTheme.typography.bodyMedium,
                     )
-                    Row(modifier = Modifier.padding(top = 4.dp)) {
+                    Row {
                         BasicTextField(
                             value = text,
                             singleLine = true,
                             onValueChange = { text = it },
+                            textStyle = MaterialTheme.typography.bodySmall,
                             keyboardActions = KeyboardActions(onDone = { run() }),
                             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                             modifier = Modifier.weight(1.0f).align(Alignment.CenterVertically),

--- a/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/components/TerminalSheet.kt
@@ -167,8 +167,9 @@ fun TerminalSheet(
             ).show()
             return
         }
-        sessionManager.exec(text.toCommand())
-        text = ""
+        text.split("\n")
+            .map { it.toCommand() }.filter { it.isNotEmpty() }
+            .toTypedArray().let { sessionManager.exec(it); text = "" }
     }
 
     ModalBottomSheet(
@@ -335,7 +336,7 @@ fun TerminalSheet(
                     Row {
                         BasicTextField(
                             value = text,
-                            singleLine = true,
+                            maxLines = 6,
                             onValueChange = { text = it },
                             textStyle = MaterialTheme.typography.bodySmall,
                             keyboardActions = KeyboardActions(onDone = { run() }),

--- a/app/src/main/java/xyz/jekyllex/utils/Commands.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Commands.kt
@@ -51,6 +51,13 @@ object Commands {
         };"
     )
 
+    fun getProjectCommands(): Array<String> = ruby(
+        "-e", "require 'safe_yaml';print SafeYAML.load_file('_config.yml')" +
+                "['jekyllex']['commands'].flat_map { |c| " +
+                    "[c['name'], c['command']]" +
+                "}.join('\u001F');"
+    )
+
     fun guessDestinationUrl(file: String) = ruby(
         "-e", "require 'jekyll';" +
                 "Jekyll.logger.log_level=:error;" +

--- a/app/src/main/java/xyz/jekyllex/utils/Settings.kt
+++ b/app/src/main/java/xyz/jekyllex/utils/Settings.kt
@@ -71,14 +71,19 @@ sealed class SettingType {
 
 enum class Setting(val key: String, val defaultValue: SettingType) {
     // General
-    TRIM_LOGS("trim_logs", SettingType.BooleanValue(true)),
-    GUESS_URLS("guess_urls", SettingType.BooleanValue(true)),
     REDUCE_ANIMATIONS("reduce_animations", SettingType.BooleanValue(false)),
+
+    // Terminal
+    TRIM_LOGS("trim_logs", SettingType.BooleanValue(true)),
+    COMMAND_TEMPLATES("command_templates", SettingType.BooleanValue(false)),
 
     // Editor
     EDITOR_THEME("editor_theme", SettingType.IntValue(0)),
-    PREVIEW_PORT("default_port", SettingType.IntValue(4000)),
     DEBOUNCE_DELAY("debounce_delay", SettingType.FloatValue(1f)),
+
+    // Preview
+    GUESS_URLS("guess_urls", SettingType.BooleanValue(true)),
+    PREVIEW_PORT("default_port", SettingType.IntValue(4000)),
 
     // Git
     GIT_NAME("git_name", SettingType.StringValue("")),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,11 @@
         Try to trim command outputs to avoid excessive log sizes in the running session.
     </string>
 
+    <string name="command_templates_title">Command templates</string>
+    <string name="command_templates_summary">
+        Parse command templates from the _config.yml file.
+    </string>
+
     <string name="reduce_animations_title">Reduce animations</string>
     <string name="reduce_animations_summary">
         Skip rendering the file/folder details on the home page.


### PR DESCRIPTION
Adds the feature to configure JekyllEx specific command templates in `_config.yml` file for each project. These command templates can be used in the app's terminal to run frequent commands quickly.

The config block could look something like:

```yml
# other config

jekyllex:
  commands:
    - name: "environment"
      command: |
        git -v
        ruby -v
        gem -v
        bundler -v
    - name: "commit"
      command: "git commit -m '<msg>'"
    - name: "deploy"
      command: "git push"
```

The feature to parse these blocks from the config file is disabled by default and should be enabled from the app settings. Once enabled the terminal shows the avialable presets in all sub folders of the project:

<img width="385" height="312" alt="image" src="https://github.com/user-attachments/assets/a6d52f6d-1547-4cf4-841c-d6a6d7cc47e1" />
