### PR TITLE
fix(editor): use evaluateJavascript instead of loadUrl("javascript:")

### DIFF
--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/webview/WebViewClient.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/webview/WebViewClient.kt
@@ -68,7 +68,7 @@ class WebViewClient(
 
         NativeUtils.exec(cat(file), CoroutineScope(Dispatchers.IO)) { content ->
             withContext(Dispatchers.Main) {
-                view.loadUrl("javascript:setText('${content.toBase64()}')")
+                view.evaluateJavascript("setText('${content.toBase64()}')", null)
             }
         }
     }


### PR DESCRIPTION
Closes #49.

`WebViewClient.onPageFinished` injects the editor's content into the page through the legacy form `loadUrl("javascript:setText('...')")`. That pattern records a synthetic history entry (so `goBack()` can land on it) and has no callback shape. `WebView.evaluateJavascript` was added in API 19 and is the documented replacement.

Swap to `evaluateJavascript`, keep the script identical:

```kotlin
view.evaluateJavascript("setText('${content.toBase64()}')", null)
```

The current call already discards any return value so `null` as the callback keeps behaviour identical.
