### PR TITLE
Guard external link launches against ActivityNotFoundException

### DIFF
--- a/app/src/main/java/xyz/jekyllex/ui/activities/editor/webview/WebViewClient.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/editor/webview/WebViewClient.kt
@@ -24,12 +24,14 @@
 
 package xyz.jekyllex.ui.activities.editor.webview
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -50,9 +52,17 @@ class WebViewClient(
         val url = request.url.toString()
         if (url.contains(EDITOR_URL) || url.contains(PREVIEW_URL)) return false
 
-        view.context.startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        )
+        try {
+            view.context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            )
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(
+                view.context,
+                "No app found to open this link",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
 
         return true
     }

--- a/app/src/main/java/xyz/jekyllex/ui/activities/viewer/WebPageViewer.kt
+++ b/app/src/main/java/xyz/jekyllex/ui/activities/viewer/WebPageViewer.kt
@@ -24,6 +24,7 @@
 
 package xyz.jekyllex.ui.activities.viewer
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -31,6 +32,7 @@ import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -93,7 +95,15 @@ class WebPageViewer : ComponentActivity() {
                                     return false
                                 }
 
-                                startActivity(Intent(Intent.ACTION_VIEW, request.url))
+                                try {
+                                    startActivity(Intent(Intent.ACTION_VIEW, request.url))
+                                } catch (e: ActivityNotFoundException) {
+                                    Toast.makeText(
+                                        this@WebPageViewer,
+                                        "No app found to open this link",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
                                 return true
                             }
 
@@ -155,9 +165,17 @@ class WebPageViewer : ComponentActivity() {
                             },
                             actions = {
                                 IconButton(onClick = {
-                                    startActivity(
-                                        Intent(Intent.ACTION_VIEW, Uri.parse(webView.url))
-                                    )
+                                    try {
+                                        startActivity(
+                                            Intent(Intent.ACTION_VIEW, Uri.parse(webView.url))
+                                        )
+                                    } catch (e: ActivityNotFoundException) {
+                                        Toast.makeText(
+                                            this@WebPageViewer,
+                                            "No app found to open this link",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    }
                                 }) {
                                     Icon(
                                         modifier = Modifier.size(20.dp),


### PR DESCRIPTION
### What

The editor preview client and the web page viewer route off-site links to an external app with a raw `startActivity(Intent(Intent.ACTION_VIEW, ...))`. When no installed app can open the target URI, that call throws `ActivityNotFoundException` and the screen crashes.

This wraps each external launch in a try/catch and shows a short toast when nothing can handle the link, matching the toast style already used elsewhere in the app. Links that do resolve behave exactly as before.

### Changes

`editor/webview/WebViewClient.kt`:

```diff
-        view.context.startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        )
+        try {
+            view.context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            )
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(
+                view.context,
+                "No app found to open this link",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
```

`viewer/WebPageViewer.kt` gets the same guard around the `shouldOverrideUrlLoading` launch and the toolbar open-in-browser action.

Closes #51
